### PR TITLE
feat: 분석 요청 시 text와 name을 함께 전달하도록 수정

### DIFF
--- a/frontend/my-app/src/app/analyze/page.tsx
+++ b/frontend/my-app/src/app/analyze/page.tsx
@@ -25,6 +25,7 @@ const Wrapper = styled.div`
 export default function Analyze() {
   const [text, setText] = useState("");
   const [score, setScore] = useState<number | null>(null);
+  const [name, setName] = useState("");
   const [success, setSuccess] = useState<boolean>(true); //false일때message 쓰기기
   const [message, setMessage] = useState<string | null>("");
   const [summary, setSummary] = useState<string | null>("");
@@ -46,6 +47,10 @@ export default function Analyze() {
     setText(e.target.value);
   };
 
+  const handleName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setName(e.target.value);
+  };
+
   const mutation = useAnalyzeMutation((data) => {
     setScore(data.score);
     setRecommendation(data.recommendation);
@@ -64,17 +69,19 @@ export default function Analyze() {
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    mutation.mutate(text);
+    mutation.mutate(text, name);
   };
 
   return (
     <Wrapper>
       <TextArea
         onSubmit={onSubmit}
-        value={text}
+        textValue={text}
         onChange={onChange}
         text={mutation.isPending ? "분석중..." : "분석하기"}
         handleFileChange={handleFileChange}
+        handleName={handleName}
+        nameValue={name}
       />
       {mutation.isPending ? (
         <Loading />

--- a/frontend/my-app/src/app/mypage/page.tsx
+++ b/frontend/my-app/src/app/mypage/page.tsx
@@ -2,6 +2,7 @@
 
 import DetailView from "@/components/ui/mypage/DetailView";
 import ListCard from "@/components/ui/mypage/ListCard";
+import { useMyPageQuery } from "@/hooks/MypageData";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
@@ -38,28 +39,23 @@ const Overlay = styled.div`
   background-color: rgb(0, 0, 0, 0.5);
 `;
 
-const data = [
-  { number: "01", name: "햄버거", recommend: 50000, score: 24 },
-  { number: "02", name: "피자", recommend: 70000, score: 65 },
-  { number: "03", name: "족발", recommend: 30000, score: 80 },
-  { number: "04", name: "보쌈", recommend: 100000, score: 100 },
-  { number: "05", name: "닭발", recommend: 70000, score: 70 },
-];
-
 function Mypage() {
+  const { data: pagedata, isLoading, isError, error } = useMyPageQuery();
   const [isAuth, setIsAuth] = useState(false);
   const router = useRouter();
   const [mounted, setMounted] = useState(false);
   const [isClick, setIsClick] = useState(false);
+  const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
 
+  console.log(pagedata);
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
     e.stopPropagation();
     setIsClick((pre) => !pre);
   };
 
-  const handleDetail = (e: React.MouseEvent<HTMLDivElement>) => {
-    e.stopPropagation();
+  const handleDetail = (idx: number) => {
     setIsClick((pre) => !pre);
+    setSelectedIdx(idx);
   };
 
   useEffect(() => {
@@ -91,22 +87,32 @@ function Mypage() {
   }, [router]);
 
   if (!mounted || !isAuth) return null;
-
+  if (isLoading) {
+    <div>로딩중</div>;
+  }
   return (
     <Wrapper>
-      {data.map((item) => (
-        <Card onClick={handleDetail}>
-          <ListCard
-            key={item.number}
-            number={item.number}
-            recommendation={item.recommend}
-            score={item.score}
-          />
-        </Card>
-      ))}
-      {isClick && (
+      {pagedata?.items.map((item, idx) => {
+        console.log("idx 확인 👀", idx);
+        return (
+          <Card onClick={() => handleDetail(idx)} key={idx}>
+            <ListCard
+              idx={idx}
+              recommendation={item.recommendation}
+              score={item.score}
+            />
+          </Card>
+        );
+      })}
+      {isClick && selectedIdx !== null && pagedata && (
         <Overlay onClick={handleOverlayClick}>
-          <DetailView onClick={() => handleDetail} />
+          <DetailView
+            idx={selectedIdx}
+            recommendation={pagedata.items[selectedIdx].recommendation}
+            score={pagedata.items[selectedIdx].score}
+            text={pagedata.items[selectedIdx].text!}
+            summary={pagedata.items[selectedIdx].summary}
+          />
         </Overlay>
       )}
     </Wrapper>

--- a/frontend/my-app/src/components/ui/TextArea/index.tsx
+++ b/frontend/my-app/src/components/ui/TextArea/index.tsx
@@ -1,23 +1,37 @@
-import { BtnBox, Button, File, Form, Text } from "./styled";
+import { BtnBox, Button, File, Form, Input, Text } from "./styled";
 
 interface ITextProps {
-  value: string;
+  textValue: string;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
   onSubmit: (e: React.FormEvent) => void;
   text: string;
   handleFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  nameValue: string;
+  handleName: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 function TextArea({
-  value,
+  textValue,
+  nameValue,
   onChange,
+  handleName,
   onSubmit,
   text,
   handleFileChange,
 }: ITextProps) {
   return (
     <Form onSubmit={onSubmit}>
-      <Text value={value} onChange={onChange}></Text>
+      <Text
+        rows={5}
+        placeholder="텍스트를 입력해주세요"
+        value={textValue}
+        onChange={onChange}
+      ></Text>
+      <Input
+        placeholder="친구이름 입력해주세요"
+        value={nameValue}
+        onChange={handleName}
+      ></Input>
       <BtnBox>
         <File>
           파일 업로드하기

--- a/frontend/my-app/src/components/ui/TextArea/styled.ts
+++ b/frontend/my-app/src/components/ui/TextArea/styled.ts
@@ -8,13 +8,11 @@ export const Form = styled.form`
   justify-content: center;
   gap: 24px;
 `;
-export const Text = styled.textarea.attrs({
-  placeholder: "텍스트를 입력해 주세요",
-  rows: 5,
-})`
+export const Text = styled.textarea`
   all: unset;
   box-sizing: border-box;
   width: 100%;
+
   border-radius: 15px;
   border: 1px solid ${(props) => props.theme.borderColor};
   padding: 10px;
@@ -48,4 +46,13 @@ export const Button = styled.button.attrs({
   padding: 8px;
   font-weight: 600;
   cursor: pointer;
+`;
+export const Input = styled.input`
+  height: 30px;
+  padding: 8px;
+  font-size: 14px;
+  border: 1px solid ${(props) => props.theme.borderColor};
+  border-radius: 8px;
+  width: 100%;
+  margin-top: 10px;
 `;

--- a/frontend/my-app/src/components/ui/mypage/DetailView.tsx
+++ b/frontend/my-app/src/components/ui/mypage/DetailView.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import ListCard from "./ListCard";
 import { Text } from "./styled";
+import { IAnalysisItem } from "@/hooks/MypageData";
 
 const Card = styled.div`
   display: flex;
@@ -42,40 +43,32 @@ const Button = styled.button`
   font-size: 14px;
 `;
 
-interface IDetailViewProps {
-  onClick: () => void;
+interface IDetailProps {
+  recommendation: string;
+  score: number;
+  summary: string;
+  text: string;
+  idx: number;
 }
 
-function DetailView({ onClick }: IDetailViewProps) {
+function DetailView({
+  recommendation,
+  score,
+  summary,
+  text,
+  idx,
+}: IDetailProps) {
   return (
     <Card>
-      <ListCard key={"01"} number={"01"} recommendation={50000} score={24} />
-      <SummaryText>
-        3줄
-        <br />
-        요약
-        <br />
-        ㅋㅋ
-      </SummaryText>
-      <ScrollBox>
-        [주머니도둑] [오후 8:54] 안녕 [주머니도둑] [오후 8:54] 나 다음달에
-        결혼해 ~^^ [뿡뿡이🥰] [오후 8:55] 정말 ?! 축하해! [주머니도둑] [오후
-        8:55] 그래서 말인데 [주머니도둑] [오후 8:55] 내 결혼식에 와줬으면 좋겠어
-        [주머니도둑] [오후 8:55] 주머니 두둑하게 [뿡뿡이🥰] [오후 8:55] 허거걱 …
-        [주머니도둑] [오후 8:54] 안녕 [주머니도둑] [오후 8:54] 나 다음달에
-        결혼해 ~^^ [뿡뿡이🥰] [오후 8:55] 정말 ?! 축하해! [주머니도둑] [오후
-        8:55] 그래서 말인데 [주머니도둑] [오후 8:55] 내 결혼식에 와줬으면 좋겠어
-        [주머니도둑] [오후 8:55] 주머니 두둑하게 [뿡뿡이🥰] [오후 8:55] 허거걱 …
-        [주머니도둑] [오후 8:54] 안녕 [주머니도둑] [오후 8:54] 나 다음달에
-        결혼해 ~^^ [뿡뿡이🥰] [오후 8:55] 정말 ?! 축하해! [주머니도둑] [오후
-        8:55] 그래서 말인데 [주머니도둑] [오후 8:55] 내 결혼식에 와줬으면 좋겠어
-        [주머니도둑] [오후 8:55] 주머니 두둑하게 [뿡뿡이🥰] [오후 8:55] 허거걱 …
-        [주머니도둑] [오후 8:54] 안녕 [주머니도둑] [오후 8:54] 나 다음달에
-        결혼해 ~^^ [뿡뿡이🥰] [오후 8:55] 정말 ?! 축하해! [주머니도둑] [오후
-        8:55] 그래서 말인데 [주머니도둑] [오후 8:55] 내 결혼식에 와줬으면 좋겠어
-        [주머니도둑] [오후 8:55] 주머니 두둑하게 [뿡뿡이🥰] [오후 8:55] 허거걱 …
-      </ScrollBox>
-      <Button onClick={onClick}> 닫기 </Button>
+      <ListCard
+        key={idx}
+        idx={idx}
+        recommendation={recommendation}
+        score={score}
+      />
+      <SummaryText>{summary}</SummaryText>
+      <ScrollBox>{text}</ScrollBox>
+      <Button> 닫기 </Button>
     </Card>
   );
 }

--- a/frontend/my-app/src/components/ui/mypage/ListCard.tsx
+++ b/frontend/my-app/src/components/ui/mypage/ListCard.tsx
@@ -1,21 +1,21 @@
+import { IAnalysisItem } from "@/hooks/MypageData";
 import ResultCircle from "../Result/ResultCircle";
-import { TextBox, Text, ListCardBox } from "./styled";
-
+import { TextBox, Text, ListCardBox, Number } from "./styled";
 interface IListProps {
-  number: string;
-  recommendation: number;
+  idx: number;
+  recommendation: string;
   score: number;
 }
 
-function ListCard({ number, recommendation, score }: IListProps) {
+function ListCard({ idx, recommendation, score }: IListProps) {
   return (
     <ListCardBox>
       <TextBox>
-        <Number>{number}</Number>
+        <Number>0{idx}</Number>
         <Text>
           상대방 : 일단빼빼
           <br />
-          추천축의금: {recommendation}원
+          추천축의금: {recommendation}
         </Text>
       </TextBox>
       <ResultCircle score={score} />

--- a/frontend/my-app/src/hooks/MypageData.ts
+++ b/frontend/my-app/src/hooks/MypageData.ts
@@ -1,0 +1,35 @@
+import { useQuery } from "@tanstack/react-query";
+
+export interface IAnalysisItem {
+  text?: string;
+  score: number;
+  recommendation: string;
+  summary: string;
+  createdAt: string;
+  idx?: number;
+}
+
+interface MyPageResponse {
+  items: IAnalysisItem[];
+}
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL!;
+
+export const fetchMyPage = async () => {
+  const token = localStorage.getItem("accessToken");
+  const res = await fetch(`${BASE_URL}/mypage`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) throw new Error("데이터를 불러오지 못했습니다.");
+  return res.json();
+};
+export function useMyPageQuery() {
+  return useQuery<MyPageResponse>({
+    queryKey: ["mypage"],
+    queryFn: fetchMyPage,
+    staleTime: 1000 * 60 * 5,
+  });
+}

--- a/frontend/my-app/src/hooks/analyzeText.ts
+++ b/frontend/my-app/src/hooks/analyzeText.ts
@@ -10,7 +10,15 @@ type AnalyzeResponse = {
   summary: string;
 };
 
-const analyzeText = async (text: string): Promise<AnalyzeResponse> => {
+interface AnalyzePayload {
+  text: string;
+  name: string;
+}
+
+const analyzeText = async ({
+  text,
+  name,
+}: AnalyzePayload): Promise<AnalyzeResponse> => {
   const token = localStorage.getItem("accessToken");
   const res = await fetch(`${BASE_URL}/api/analyze`, {
     method: "POST",
@@ -18,7 +26,7 @@ const analyzeText = async (text: string): Promise<AnalyzeResponse> => {
       "Content-Type": "application/json",
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({ text }),
+    body: JSON.stringify({ text, name }),
   });
 
   if (!res.ok) {
@@ -32,7 +40,7 @@ const analyzeText = async (text: string): Promise<AnalyzeResponse> => {
 
 export const useAnalyzeMutation = (
   onSuccessCallback: (data: AnalyzeResponse) => void
-): UseMutationResult<AnalyzeResponse, Error, string> => {
+): UseMutationResult<AnalyzeResponse, Error, AnalyzePayload> => {
   return useMutation({
     mutationFn: analyzeText,
 


### PR DESCRIPTION
- useMutation의 mutationFn 인자를 기존 string → 객체(AnalyzePayload)로 변경
- AnalyzePayload 타입 정의: text와 name 포함
- analyzeText 함수 내 fetch 요청 body에 name 추가
- mutation 호출부에서 mutate({ text, name }) 형식 사용 가능하게 변경